### PR TITLE
[#13] Fix WebSocket connection on remote host

### DIFF
--- a/src/client/src/socket.js
+++ b/src/client/src/socket.js
@@ -6,7 +6,7 @@ const SLUG_EVENT = 'slug';
 class Socket {
     constructor(presetSlug, ioSocket) {
         this.socket = ioSocket || io(
-            `ws://${window.location.hostname}:${process.env.PORT || '5000'}`,
+            `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.hostname}:${process.env.PORT || '5000'}`,
             {transports: ['websocket']});
         this.slug = presetSlug;
         this.registeredHandlers = [];

--- a/src/client/src/socket.js
+++ b/src/client/src/socket.js
@@ -6,7 +6,7 @@ const SLUG_EVENT = 'slug';
 class Socket {
     constructor(presetSlug, ioSocket) {
         this.socket = ioSocket || io(
-            `ws://localhost:${process.env.PORT || '5000'}`,
+            `ws://${window.location.hostname}:${process.env.PORT || '5000'}`,
             {transports: ['websocket']});
         this.slug = presetSlug;
         this.registeredHandlers = [];

--- a/src/client/src/socket.js
+++ b/src/client/src/socket.js
@@ -5,9 +5,7 @@ const SLUG_EVENT = 'slug';
 
 class Socket {
     constructor(presetSlug, ioSocket) {
-        this.socket = ioSocket || io(
-            `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.hostname}:${process.env.PORT || '5000'}`,
-            {transports: ['websocket']});
+        this.socket = ioSocket || io(this.getSocketAddress(), {transports: ['websocket']});
         this.slug = presetSlug;
         this.registeredHandlers = [];
         this.unregisteredHandlers = [];
@@ -25,6 +23,14 @@ class Socket {
              that.registeredHandlers = that.registeredHandlers.concat(that.unregisteredHandlers);
              that.unregisteredHandlers = [];
         });
+    };
+    getSocketAddress() {
+        let address = window.location.protocol === 'https:' ? 'wss' : 'ws';
+        address += `://${window.location.hostname}`;
+        if (window.location.host.includes(":")) {
+            address += `:${process.env.PORT || '5000'}`;
+        }
+        return address;
     };
     sendMessage(message) {
         this.socket.emit(this.slug + CHAT_EVENT, message);


### PR DESCRIPTION
### Issue
#13

### Notes
1. Remote host was failing to connect to websocket, because it used hardcoded `localhost`
1. Ensure we handle websocket protocol and hostname correctly

### Testing
1. Verified on locahost
1. Verified on Heroku (manual deploy)

![image](https://user-images.githubusercontent.com/5824989/62873856-f91c9780-bcd4-11e9-8ca9-9ce5c8cfcd35.png)
