### PR TITLE
Simplify socket management

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+trim_trailing_whitespace = true
+indent_size = 4
+tab_width = 4

--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,3 @@
+{
+    "editorconfig": true
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
           "client": "cd src/client && npm start",
           "test-client": "cd src/client && npm test",
           "server": "cd src/server && npm start",
+          "server-dev": "cd src/server && npm run dev",
           "test-server": "cd src/server && npm test",
-          "dev": "concurrently --kill-others-on-fail \"npm run server\" \"npm run client\"",
+          "dev": "concurrently --kill-others-on-fail \"npm run server-dev\" \"npm run client\"",
           "test": "concurrently --success all \"npm run test-server\" \"npm run test-client\"",
           "heroku-postbuild": "cd src/client && npm run build"
      },

--- a/src/client/src/App.js
+++ b/src/client/src/App.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import logo from './logo.svg';
 import './App.css';
 import Socket from './socket'
+import SlugManager from './slug';
 import {Conversation, Message, Sender} from './message'
 
 class App extends Component {
@@ -10,6 +11,11 @@ class App extends Component {
         text: '',
         user: new Sender(prompt('What\'s your name?')),
         conversation: new Conversation(),
+        slugManager: new SlugManager(),
+        userCount: 1,
+    }
+    updateUserCount(count) {
+        this.setState({userCount: count});
     }
     componentDidMount() {
         this.socket.subscribeToMessages((data) => {
@@ -20,6 +26,13 @@ class App extends Component {
         if (!this.state.user.name) {
             this.setState({user: new Sender('Anonymous')});
         }
+        this.socket.handleUserCountChange((userCount) => {
+            this.updateUserCount(userCount);
+        })
+        this.socket.join(this.state.slugManager.currentSlug(), (welcomePackage) => {
+             this.state.slugManager.changeSlug(welcomePackage.slug);
+             this.updateUserCount(welcomePackage.userCount);
+        });
     }
     onKeyPress = event => {
          if (event.key === ' ') {
@@ -39,7 +52,7 @@ class App extends Component {
             text: "",
             conversation: previousState.conversation.addMessage(newMessage),
         }));
-        this.socket.sendMessage(newMessage);
+        this.socket.chat(newMessage);
     };
     render() {
         return (

--- a/src/client/src/__tests__/socket.test.js
+++ b/src/client/src/__tests__/socket.test.js
@@ -1,5 +1,4 @@
 import sinon from 'sinon';
-import io from 'socket.io-client';
 
 import Socket from '../socket'
 
@@ -10,136 +9,29 @@ it('creates a socket instance', () => {
 });
 
 it('sends a message through socket.io', () => {
-    const slug = 'SLUG';
     const socket = new Socket();
     const ioSpy = sinon.spy(socket.socket, 'emit');
     const message = 'Test Message';
-    socket.slug = slug;
 
-    socket.sendMessage(message);
+    socket.chat(message);
 
-    expect(ioSpy.withArgs(slug + 'chat', message).called).toBe(true);
+    expect(ioSpy.withArgs('chat', message).called).toBe(true);
 });
 
-it('can subscribe before receiving slug', () => {
+it('can subscribe to messsages', () => {
+    const message = 'Hello World';
     const socket = new Socket();
-    const handler = function(message) {
-        console.log(message);
+    let wasCalled = false;
+    const handler = function(receivedMessage) {
+        wasCalled = true;
+        expect(message).toBe(receivedMessage);
     };
-    const ioSpy = sinon.spy(socket.socket, 'on');
 
     socket.subscribeToMessages(handler);
+    socket.handleMessageReceived(message);
 
-    expect(ioSpy.withArgs(sinon.match.any, handler).called).toBe(false);
-    expect(socket.unregisteredHandlers).toEqual(
+    expect(socket.messageHandlers).toEqual(
         expect.arrayContaining([handler])
     );
-});
-
-it('can subscribe handlers after receiving slug', () => {
-    const slug = 'abcd1';
-    const socket = new Socket();
-    const handler = function(message) {
-        console.log(message);
-    };
-    const ioSpy = sinon.spy(socket.socket, 'on');
-    socket.slug = slug;
-
-    socket.subscribeToMessages(handler);
-
-    expect(ioSpy.withArgs(slug + 'chat', handler).called).toBe(true);
-    expect(socket.registeredHandlers).toEqual(
-        expect.arrayContaining([handler])
-    );
-});
-
-it('forwards received messages to handlers', () => {
-    const socket = new Socket();
-    const expectedMessage = 'Hello World';
-    const ioStub = sinon.stub(socket.socket, 'on');
-    const handler = sinon.spy(function(message) {
-        expect(message).toBe(expectedMessage);
-    });
-    socket.slug = '1234';
-
-    socket.subscribeToMessages(handler);
-    ioStub.callArgWith(1, expectedMessage);
-
-    expect(handler.withArgs(expectedMessage).called).toBe(true);
-});
-
-it('fires change slug if slug is preset', () => {
-    const ioSocket = io();
-    const ioSpy = sinon.spy(ioSocket, 'emit');
-    const presetSlug = 'SLUGGY';
-
-    const socket = new Socket(presetSlug, ioSocket);
-
-    expect(socket).toBeTruthy();
-    expect(ioSpy.withArgs('change-slug', presetSlug).called).toBe(true);
-});
-
-it('does not fire change slug on slug as empty string', () => {
-    const ioSocket = io();
-    const ioSpy = sinon.spy(ioSocket, 'emit');
-
-    const socket = new Socket('', ioSocket);
-
-    expect(socket).toBeTruthy();
-    expect(ioSpy.withArgs('change-slug',
-                          sinon.match.any).called).toBe(false);
-});
-
-it('updates the slug on the slug event', () => {
-    const ioSocket = io();
-    const ioStub = sinon.stub(ioSocket, 'on');
-    const socket = new Socket('', ioSocket);
-    const newSlug = 'NEW_SLUG';
-
-    ioStub.callArgWith(1, newSlug);
-
-    expect(socket.slug).toEqual(newSlug);
-});
-
-it('updates the message name of a handler on slug change', () => {
-    const ioSocket = io();
-    const ioSpy = sinon.spy(ioSocket, 'on');
-    const socket = new Socket('', ioSocket);
-    const newSlug = 'NEW_SLUG';
-    const handler = function(message) {
-        console.log(message);
-    };
-    socket.subscribeToMessages(handler);
-
-    ioSpy.callArgWith(1, newSlug);
-
-    expect(socket.slug).toEqual(newSlug);
-    expect(ioSpy.withArgs(newSlug + 'chat', handler).called).toBe(true);
-    expect(socket.registeredHandlers).toEqual(
-        expect.arrayContaining([handler])
-    );
-});
-
-it('updates the message name for mulitple handlers on slug change', () => {
-    const ioSocket = io();
-    const ioSpy = sinon.spy(ioSocket, 'on');
-    const socket = new Socket('', ioSocket);
-    const newSlug = 'NEW_SLUG';
-    const handler1 = function(message) {
-        console.log(message);
-    };
-    const handler2 = function(message) {
-        console.log(message);
-    };
-    socket.subscribeToMessages(handler1);
-    socket.subscribeToMessages(handler2);
-
-    ioSpy.callArgWith(1, newSlug);
-
-    expect(socket.slug).toEqual(newSlug);
-    expect(ioSpy.withArgs(newSlug + 'chat', handler1).called).toBe(true);
-    expect(ioSpy.withArgs(newSlug + 'chat', handler2).called).toBe(true);
-    expect(socket.registeredHandlers).toEqual(
-        expect.arrayContaining([handler1, handler2])
-    );
+    expect(wasCalled).toBeTruthy();
 });

--- a/src/client/src/slug.js
+++ b/src/client/src/slug.js
@@ -1,0 +1,13 @@
+class SlugManager {
+    currentSlug() {
+        return document.location.pathname.replace('/', '');
+    };
+    changeSlug(slug) {
+        if (this.currentSlug() === slug) {
+            return;
+        }
+        window.history.pushState('chat', 'My Chat', `/${slug}`);
+    };
+}
+
+export default SlugManager;

--- a/src/client/src/socket.js
+++ b/src/client/src/socket.js
@@ -1,27 +1,18 @@
 import io from 'socket.io-client';
 
 const CHAT_EVENT = 'chat';
-const SLUG_EVENT = 'slug';
 
 class Socket {
     constructor(presetSlug, ioSocket) {
-        this.socket = ioSocket || io(this.getSocketAddress(), {transports: ['websocket']});
-        this.slug = presetSlug;
-        this.registeredHandlers = [];
-        this.unregisteredHandlers = [];
-        if (this.slug) {
-            this.socket.emit('change-slug', this.slug);
-            return;
-        }
-        let that = this;
-        this.socket.on(SLUG_EVENT, function(data) {
-             that.slug = data;
-             window.history.pushState('chat', 'My Chat', '/' + that.slug);
-             that.unregisteredHandlers.forEach((h) => {
-                 that.socket.on(that.slug + CHAT_EVENT, h);
-             });
-             that.registeredHandlers = that.registeredHandlers.concat(that.unregisteredHandlers);
-             that.unregisteredHandlers = [];
+        this.socket = ioSocket || io(this.getSocketAddress(), {
+            transports: ['websocket']
+        });
+        this.messageHandlers = [];
+        this.socket.on(CHAT_EVENT, this.handleMessageReceived);
+    };
+    handleMessageReceived(message) {
+        this.messageHandlers.forEach((h) => {
+            h(message);
         });
     };
     getSocketAddress() {
@@ -32,17 +23,26 @@ class Socket {
         }
         return address;
     };
-    sendMessage(message) {
-        this.socket.emit(this.slug + CHAT_EVENT, message);
-    };
+
     subscribeToMessages(handler) {
-        if (this.slug) {
-            this.registeredHandlers.push(handler);
-            this.socket.on(this.slug + CHAT_EVENT, handler);
-        } else {
-            this.unregisteredHandlers.push(handler);
-        }
-    }
+        this.messageHandlers.push(handler);
+    };
+    join(currentSlug, onWelcome) {
+        this.socket.on('welcome', (welcomePackage) => {
+            onWelcome(welcomePackage);
+        });
+        this.socket.emit('join', {
+            slug: currentSlug
+        });
+    };
+    handleUserCountChange(onUserCountChange) {
+        this.socket.on('user-count', (userCount) => {
+            onUserCountChange(userCount);
+        });
+    };
+    chat(message) {
+        this.socket.emit(CHAT_EVENT, message);
+    };
 }
 
 export default Socket;

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "scripts": {
         "start": "node src/server.js",
+        "dev": "nodemon src/server.js",
         "test": "jest --verbose"
     },
     "dependencies": {
@@ -19,6 +20,7 @@
         }
     },
     "devDependencies": {
-        "jest": "^24.7.1"
+        "jest": "^24.7.1",
+        "nodemon": "^1.19.4"
     }
 }


### PR DESCRIPTION
### Notes
1. Add `EditorConfig` and `AtomBeautify` support to help cleanup formatting
1. Add `nodemon` to support live reloading server 
1. Greatly simplify socket management through [use of rooms](https://socket.io/docs/rooms-and-namespaces/)

### Testing
1. Verified on `localhost`
1. Unit tests